### PR TITLE
Handle formatting in strings transparently

### DIFF
--- a/examples/quick_brown_fox.py
+++ b/examples/quick_brown_fox.py
@@ -1,0 +1,9 @@
+from junction import Terminal, Root, Text
+
+term = Terminal()
+text = Text(
+    term.bold + 'The ' + term.normal + 'quick ' + term.red('brown') + ' fox ' +
+    term.underline('jumps') +
+    ' over {t.green_on_white}the lazy{t.normal} dog'.format(t=term))
+root = Root(text)
+root.run()

--- a/junction/base.py
+++ b/junction/base.py
@@ -1,6 +1,8 @@
 from abc import ABCMeta, abstractmethod
 from collections import namedtuple
 
+from .terminal import get_terminal
+
 
 Geometry = namedtuple(
     'Geometry', ['width', 'height', 'x', 'y', 'x_crop', 'y_crop'])
@@ -24,7 +26,7 @@ class ABCUIElement(metaclass=ABCMeta):
         self.valign = valign
         self.fillchar = fillchar
         self.name = name
-        self.terminal = None
+        self._terminal = None
         self.updated = True
         self._previous_geometry = None
         self.default_format = None
@@ -72,6 +74,14 @@ class ABCUIElement(metaclass=ABCMeta):
     @valign.setter
     def valign(self, value):
         self._set_align('vertical', value)
+
+    @property
+    def terminal(self):
+        return self._terminal or get_terminal()
+
+    @terminal.setter
+    def terminal(self, terminal):
+        self._terminal = terminal
 
     def draw(self, width, height, x=0, y=0, x_crop='left', y_crop='top'):
         self._draw(width, height, x, y, x_crop, y_crop)

--- a/junction/base.py
+++ b/junction/base.py
@@ -27,6 +27,7 @@ class ABCUIElement(metaclass=ABCMeta):
         self.terminal = None
         self.updated = True
         self._previous_geometry = None
+        self.default_format = None
 
     def __repr__(self):
         if self.name:

--- a/junction/container_elements.py
+++ b/junction/container_elements.py
@@ -8,7 +8,6 @@ class ABCContainerElement(ABCUIElement):
     def __init__(self, elements=None, *args, **kwargs):
         self._content = []
         self._active_element = None
-        self._terminal = None
         super().__init__(*args, **kwargs)
         elements = elements or []
         for element in elements:
@@ -19,7 +18,7 @@ class ABCContainerElement(ABCUIElement):
 
     @property
     def terminal(self):
-        return self._terminal
+        return self._terminal or get_terminal()
 
     @terminal.setter
     def terminal(self, terminal):

--- a/junction/display_elements.py
+++ b/junction/display_elements.py
@@ -89,4 +89,7 @@ class Text(ABCDisplayElement):
         self.content = content
 
     def _get_block(self, width, height):
-        return wrap(self.content, width)
+        lines = wrap(self.content, width)
+        if any(isinstance(line, StringWithFormatting) for line in lines):
+            lines[-1] += self.terminal.normal
+        return lines

--- a/junction/display_elements.py
+++ b/junction/display_elements.py
@@ -39,7 +39,7 @@ class ABCDisplayElement(ABCUIElement):
         # Perform an additional crop with *different alignment* to resize the
         # UI element's rendered area text to the required area:
         block = self._do_crop(block, width, height, x_crop, y_crop)
-        term.draw_block(block, x, y)
+        term.draw_block(block, x, y, self.default_format)
 
     def _update(self):
         self._draw(*self._previous_geometry)

--- a/junction/display_elements.py
+++ b/junction/display_elements.py
@@ -1,9 +1,9 @@
 from abc import abstractmethod
-from textwrap import wrap
 
 from .base import ABCUIElement
 from .util import clamp, crop_or_expand
 from .terminal import get_terminal
+from .formatting import StringWithFormatting, wrap
 
 
 class ABCDisplayElement(ABCUIElement):

--- a/junction/formatting.py
+++ b/junction/formatting.py
@@ -101,8 +101,6 @@ class StringWithFormatting:
     def __radd__(self, other):
         if isinstance(other, (str, Format)):
             return self.__class__((other,) + self._content)
-        else:
-            return self.__class__(other._content + self._content)
 
     def _enumerate_chars(self):
         num_chars = 0

--- a/junction/formatting.py
+++ b/junction/formatting.py
@@ -220,7 +220,7 @@ class TextWrapper:
         '''Generator that splits a string-like object (which can include our
         StringWithFormatting) into chunks at whitespace boundaries.
         '''
-        current_chunk = None
+        current_chunk = ''  # Default if we have no characters
         previous_char_type = None
         for char in string_like:
             if isinstance(char, Format):
@@ -270,22 +270,27 @@ class TextWrapper:
         while chunks:
             self._lstrip(chunks)
             current_line = []
-            current_length = 0
+            current_line_length = 0
+            current_chunk_length = 0
             while chunks:
-                l = len(chunks[0])
-                if current_length + l <= self.width:
+                current_chunk_length = len(chunks[0])
+                if current_line_length + current_chunk_length <= self.width:
                     current_line.append(chunks.pop(0))
-                    current_length += l
+                    current_line_length += current_chunk_length
                 else:
                     # Line is full
                     break
             # Handle case where chunk is bigger than an entire line
-            if l > self.width:
-                space_left = self.width - current_length
+            if current_chunk_length > self.width:
+                space_left = self.width - current_line_length
                 current_line.append(chunks[0][:space_left])
                 chunks[0] = chunks[0][space_left:]
             self._rstrip(current_line)
-            result.append(reduce(lambda x, y: x + y, current_line, ''))
+            if current_line:
+                result.append(reduce(
+                    lambda x, y: x + y, current_line[1:], current_line[0]))
+            else:
+                result.append('')
         return result
 
 

--- a/junction/formatting.py
+++ b/junction/formatting.py
@@ -1,0 +1,147 @@
+from blessings import ParametrizingString
+
+
+class Format:
+    '''A wrapper for blessings.Terminal formatting commands that will delay the
+    call to retrieve formatting until we're actually drawing an element. This
+    means that parent elements could change style properties such as normal and
+    we stay up-to-date.
+    '''
+    def __init__(self, escape_sequence, name=None):
+        '''
+        :parameter escape_sequence: the text-formatting terminal escape
+            sequence this Format object is to encapsulate, or None if this
+            object is to act like the 'normal' format, but where 'normal' could
+            potentially be another format defined arbitrarily.
+        '''
+        self.escape_sequence = escape_sequence
+        self.name = name
+
+    def __str__(self):
+        return self.escape_sequence
+
+    def __repr__(self):
+        return '{}({})'.format(
+            self.__class__.__name__, self.name or repr(self.escape_sequence))
+
+    def __call__(self, *args):
+        if isinstance(self.escape_sequence, ParametrizingString):
+            return self.__class__(self.escape_sequence(*args), name=self.name)
+        else:
+            # Emulate the behaviour of blessings.FormattingString, but with our
+            # StringWithFormatting objects instead
+            result = self
+            for word in args:
+                result += word
+            result += Format(None)
+            return result
+
+    def __eq__(self, other):
+        if hasattr(other, 'escape_sequence'):
+            return self.escape_sequence == other.escape_sequence
+        else:
+            return False
+
+    def __add__(self, other):
+        if isinstance(other, StringWithFormatting):
+            return other.__radd__(self)
+        else:
+            return StringWithFormatting((self, other))
+
+    def __radd__(self, other):
+        return StringWithFormatting((other, self))
+
+    def draw(self, normal):
+        return self.escape_sequence or normal
+
+
+class StringWithFormatting:
+    def __init__(self, content):
+        self._content = tuple(content)
+
+    def __repr__(self):
+        return '{}({})'.format(
+            self.__class__.__name__, ', '.join(repr(s) for s in self._content))
+
+    def __str__(self):
+        return ''.join(s for s in self._content if not isinstance(s, Format))
+
+    def __len__(self):
+        return len(str(self))
+
+    def __contains__(self, obj):
+        if isinstance(obj, Format):
+            return obj in self._content
+        else:
+            return obj in str(self)
+
+    def __eq__(self, other):
+        if hasattr(other, '_content'):
+            return self._content == other._content
+        else:
+            return False
+
+    def __add__(self, other):
+        if isinstance(other, (str, Format)):
+            return self.__class__(self._content + (other,))
+        else:
+            return self.__class(self._content + other._content)
+
+    def __radd__(self, other):
+        if isinstance(other, (str, Format)):
+            return self.__class__((other,) + self._content)
+        else:
+            return self.__class__(other._content + self._content)
+
+    def _enumerate_chars(self):
+        num_chars = 0
+        for string in self._content:
+            if isinstance(string, Format):
+                yield num_chars, string
+            else:
+                for char in string:
+                    num_chars += 1
+                    yield num_chars, char
+
+    def _get_slice(self, start, stop):
+        start = start if start is not None else 0
+        stop = stop if stop is not None else len(self)
+        stop = min(stop, len(self))
+        result = []
+        string = ''
+        first_format = []
+        for i, char in self._enumerate_chars():
+            if start < i <= stop:
+                if isinstance(char, Format):
+                    if string:
+                        result.append(string)
+                        string = ''
+                    result.append(char)
+                else:
+                    string += char
+            else:
+                if isinstance(char, Format):
+                    first_format.append(char)
+            if i == stop:
+                if first_format:
+                    result[0:0] = first_format
+                if string:
+                    result.append(string)
+                break
+        return self.__class__(result)
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            return self._get_slice(index.start, index.stop)
+        else:
+            return str(self)[index]
+
+    def _iter_for_draw(self, normal):
+        for string in self._content:
+            if isinstance(string, Format):
+                yield string.draw(normal)
+            else:
+                yield string
+
+    def draw(self, normal):
+        return ''.join(string for string in self._iter_for_draw(normal))

--- a/junction/formatting.py
+++ b/junction/formatting.py
@@ -61,7 +61,7 @@ class Format(str):
             result = self
             for word in args:
                 result += word
-            result += Format(None)
+            result += Format(None, name='normal')
             return result
 
     def __add__(self, other):

--- a/junction/formatting.py
+++ b/junction/formatting.py
@@ -85,7 +85,7 @@ class StringWithFormatting:
         if isinstance(other, (str, Format)):
             return self.__class__(self._content + (other,))
         else:
-            return self.__class(self._content + other._content)
+            return self.__class__(self._content + other._content)
 
     def __radd__(self, other):
         if isinstance(other, (str, Format)):

--- a/junction/formatting.py
+++ b/junction/formatting.py
@@ -10,6 +10,8 @@ class Format(str):
     StringWithFormatting objects that can be processed like strings without
     terminal escape sequences in them for the purposes of layout generation
     (i.e. using slices), but will preserve formatting.
+
+    We derive from string so that we can be easily written out to a stream.
     '''
     __slots__ = ('_normal', '_orig_class', 'name')
 

--- a/junction/terminal.py
+++ b/junction/terminal.py
@@ -1,11 +1,37 @@
 import blessings
 
+from .formatting import Format, StringWithFormatting
+
 
 class Terminal(blessings.Terminal):
-    def draw_block(self, block, x, y):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._normal = super()._resolve_formatter('normal')
+        # Because we override blessings.Terminal's formatter lookup to return
+        # our own Format objects, we have to make the stream smart about
+        # converting them for writing. (Deriving format str would have played
+        # badly with blessing's own str-derived objects.)
+        orig_stream_write = self.stream.write
+        def format_aware_stream_write(data):
+            if isinstance(data, Format):
+                orig_stream_write(str(data))
+            else:
+                orig_stream_write(data)
+        self.stream.write = format_aware_stream_write
+
+    def draw_block(self, block, x, y, normal=None):
         for y, line in enumerate(block, start=y):
             self.stream.write(self.move(y, x))
+            if isinstance(line, StringWithFormatting):
+                line = line.draw(normal or self._normal)
             self.stream.write(line)
+
+    def _resolve_formatter(self, name):
+        if name == 'normal':
+            resolved = None
+        else:
+            resolved = super()._resolve_formatter(name)
+        return Format(resolved, name=name)
 
 _terminal = Terminal()
 

--- a/junction/terminal.py
+++ b/junction/terminal.py
@@ -9,6 +9,8 @@ class Terminal(blessings.Terminal):
         self._normal = super()._resolve_formatter('normal')
 
     def draw_block(self, block, x, y, normal=None):
+        if normal is not None:
+            self.stream.write(normal)
         for y, line in enumerate(block, start=y):
             self.stream.write(self.move(y, x))
             if isinstance(line, StringWithFormatting):

--- a/junction/terminal.py
+++ b/junction/terminal.py
@@ -7,17 +7,6 @@ class Terminal(blessings.Terminal):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._normal = super()._resolve_formatter('normal')
-        # Because we override blessings.Terminal's formatter lookup to return
-        # our own Format objects, we have to make the stream smart about
-        # converting them for writing. (Deriving format str would have played
-        # badly with blessing's own str-derived objects.)
-        orig_stream_write = self.stream.write
-        def format_aware_stream_write(data):
-            if isinstance(data, Format):
-                orig_stream_write(str(data))
-            else:
-                orig_stream_write(data)
-        self.stream.write = format_aware_stream_write
 
     def draw_block(self, block, x, y, normal=None):
         for y, line in enumerate(block, start=y):

--- a/junction/util.py
+++ b/junction/util.py
@@ -23,22 +23,20 @@ def crop_or_expand(iterable, length, default=' ', scheme='beginning'):
             result = iterable[-length:]
     elif len(iterable) < length:
         # Expand:
-        if not isinstance(default, type(iterable)):
-            # Duck-typing is good, but we're trying to avoid some hard-to-debug
-            # messages more.
-            raise TypeError(
-                "Can't crop or expand the given iterable of type {!r} with "
-                "default value of type {!r}".format(
-                    type(iterable), type(default)))
         missing = length - len(iterable)
-        if scheme == 'beginning':
-            result = iterable + default * missing
-        elif scheme == 'middle':
-            result = (default * ((missing + 1) // 2) +
-                      iterable +
-                      default * (missing // 2))
-        elif scheme == 'end':
-            result = default * missing + iterable
+        try:
+            if scheme == 'beginning':
+                result = iterable + default * missing
+            elif scheme == 'middle':
+                result = (default * ((missing + 1) // 2) +
+                          iterable +
+                          default * (missing // 2))
+            elif scheme == 'end':
+                result = default * missing + iterable
+        except TypeError:
+            raise TypeError(
+                "Can't expand the given iterable of type {!r} with default "
+                "value of type {!r}".format(type(iterable), type(default)))
     else:
         # Perfect :-)
         result = iterable[:]

--- a/test/test_elements.py
+++ b/test/test_elements.py
@@ -26,6 +26,9 @@ class ContainerElementForTest(ABCContainerElement):
 
 
 class TestDisplayElements(TestCase):
+    def setUp(self):
+        self.terminal = Terminal(force_styling=True)
+
     def test_set_get_alignment(self):
         fill = Fill()
         fill.valign = 'middle'
@@ -88,6 +91,29 @@ class TestDisplayElements(TestCase):
             'fox jumps over///',
             'the lazy dog/////']
         self.assertEqual(text._get_cropped_block(17, 4), expected)
+
+    def test_text_with_formatting(self):
+        content = (
+            self.terminal.bold + 'The ' + self.terminal.normal + 'quick ' +
+            self.terminal.red('brown') + ' fox ' +
+            self.terminal.underline('jumps'))  # +
+            #' over {t.green_on_white}the lazy{t.normal} dog'.format(
+            #    t=self.terminal))
+            # FIXME: can't yet handle .format insertion of Format objects into
+            # strings
+        text = Text(content)
+        expected = [
+            (self.terminal.bold + 'The ' + self.terminal.normal + 'quick ' +
+             self.terminal.red + 'brown' + self.terminal.normal + '  '),
+            ('fox ' + self.terminal.underline + 'jumps' +
+             self.terminal.normal + self.terminal.normal + '        '),
+            #+ ' over ' + self.terminal.green_on_white),
+            #('the lazy' + self.terminal.normal + ' dog' +
+            # self.terminal.normal + '     '),
+            '                 ',
+            '                 ']
+        actual = text._get_cropped_block(17, 4)
+        self.assertEqual(actual, expected)
 
 
 class TestContainerElements(TestCase):

--- a/test/test_elements.py
+++ b/test/test_elements.py
@@ -120,7 +120,7 @@ class TestContainerElements(TestCase):
         root.testing = True  # FIXME just whilst we're blocking with input()
         root.run()
         self.terminal.draw_block.assert_called_with(
-            ['....', '....', '....', '....'], 0, 0)
+            ['....', '....', '....', '....'], 0, 0, fill.default_format)
 
     def test_stack_limits(self):
         stack = Stack()
@@ -143,41 +143,43 @@ class TestContainerElements(TestCase):
 
     def test_stack(self):
         fill1 = Fill('1', name='1')
+        fill1.default_format = 'kinda oney'
         fill2 = Fill('2', name='2')
+        fill2.default_format = 'more like two'
         fill2.min_height = 2
         stack = Stack([fill1, fill2])
         stack.terminal = self.terminal
         stack.draw(5, 4)
         self.terminal.draw_block.assert_has_calls([
-            call(['11111'], 0, 0),
-            call(['22222', '22222'], 0, 1)])
+            call(['11111'], 0, 0, fill1.default_format),
+            call(['22222', '22222'], 0, 1, fill2.default_format)])
         self.terminal.draw_block.reset_mock()
         self.assertIsNone(stack.min_width)
         stack.draw(3, 2)
         self.terminal.draw_block.assert_has_calls([
-            call(['111'], 0, 0),
-            call(['222'], 0, 1)])
+            call(['111'], 0, 0, fill1.default_format),
+            call(['222'], 0, 1, fill2.default_format)])
         self.terminal.draw_block.reset_mock()
         stack.draw(4, 1)
         self.terminal.draw_block.assert_has_calls([
-            call(['1111'], 0, 0)])
+            call(['1111'], 0, 0, fill1.default_format)])
         self.terminal.draw_block.reset_mock()
         stack.valign = 'bottom'
         stack.draw(3, 2)
         self.terminal.draw_block.assert_has_calls([
-            call(['222', '222'], 0, 0)])
+            call(['222', '222'], 0, 0, fill2.default_format)])
         self.terminal.draw_block.reset_mock()
         fill3 = Fill('3', name='3')
         stack.add_element(fill3)
         stack.draw(5, 4)
         self.terminal.draw_block.assert_has_calls([
-            call(['33333'], 0, 3),
-            call(['22222', '22222'], 0, 1),
-            call(['11111'], 0, 0)])
+            call(['33333'], 0, 3, fill3.default_format),
+            call(['22222', '22222'], 0, 1, fill2.default_format),
+            call(['11111'], 0, 0, fill1.default_format)])
         self.terminal.draw_block.reset_mock()
         stack.remove_element(fill2)
         stack.draw(5, 4)
         self.terminal.draw_block.assert_has_calls([
-            call(['33333'], 0, 3),
-            call(['11111'], 0, 2)])
+            call(['33333'], 0, 3, fill3.default_format),
+            call(['11111'], 0, 2, fill1.default_format)])
         self.terminal.draw_block.reset_mock()

--- a/test/test_formatted_string.py
+++ b/test/test_formatted_string.py
@@ -1,0 +1,120 @@
+from unittest import TestCase
+#from mock import patch
+
+from junction.formatting import Format, StringWithFormatting
+#from junction import Terminal, Fill, Text, Stack
+
+
+#class TestFormattingBehviour(TestCase):
+#    def setUp(self):
+#        self.terminal = Terminal(force_styling=True)
+#
+#    @patch('junction.Terminal.draw_block', autospec=True)
+#    def _test_default_formatting(self, mock_draw_block):
+#        fill = Fill()
+#        fill.terminal = self.terminal
+#        fill.default_format = self.terminal.bold + self.terminal.green
+#        fill
+#
+#    def _test_formatting_in_content(self):
+#        text = Text(
+#            self.terminal.bold + 'The ' + self.terminal.normal + 'quick ' +
+#            self.terminal.red('brown') + ' fox ' +
+#            self.terminal.underline('jumps') +
+#            ' over {t.green_on_white}the lazy{t.normal} dog'.format(
+#                t=self.terminal))
+#
+#    def _test_default_formatting_inherited_in_container(self):
+#        pass
+
+
+class TestFormat(TestCase):
+    def test_draw(self):
+        f = Format('Some escape sequence')
+        self.assertEqual(f.draw('Whatever is normal?'), 'Some escape sequence')
+        f = Format(None)
+        self.assertEqual(f.draw('Am I normal?'), 'Am I normal?')
+
+    def test_equality(self):
+        self.assertEqual(Format('foo'), Format('foo'))
+        self.assertNotEqual(Format('foo'), Format('bar'))
+
+    def test_addition(self):
+        swf = Format('Hello') + 'World'
+        self.assertIsInstance(swf, StringWithFormatting)
+        self.assertIn(Format('Hello'), swf)
+        self.assertIn('World', swf)
+        swf = 'Hello' + Format('World')
+        self.assertIsInstance(swf, StringWithFormatting)
+        self.assertIn('Hello', swf)
+        self.assertIn(Format('World'), swf)
+
+
+class TestStringWithFormatting(TestCase):
+    def setUp(self):
+        self.swf = 'Hello ' + Format('hiding') + 'World!'
+
+    def test_len(self):
+        self.assertEqual(len(self.swf), len('Hello World!'))
+
+    def test_str(self):
+        self.assertEqual(str(self.swf), 'Hello World!')
+
+    def test_draw(self):
+        self.assertEqual(self.swf.draw('normal'), 'Hello hidingWorld!')
+
+    def test_equality(self):
+        self.assertEqual(self.swf, 'Hello ' + Format('hiding') + 'World!')
+        self.assertEqual(self.swf, StringWithFormatting(
+            ('Hello ', Format('hiding'), 'World!')))
+        self.assertNotEqual(self.swf, StringWithFormatting('Hello World!'))
+
+    def test_addition(self):
+        long_swf = 'Prefix' + self.swf
+        self.assertIsInstance(long_swf, StringWithFormatting)
+        self.assertEqual(str(long_swf), 'PrefixHello World!')
+        long_swf = Format('PrePrefixFormat') + long_swf
+        self.assertIsInstance(long_swf, StringWithFormatting)
+        self.assertEqual(long_swf._content, (
+            Format('PrePrefixFormat'), 'Prefix', 'Hello ', Format('hiding'),
+            'World!'))
+        long_swf = self.swf + 'Suffix'
+        self.assertIsInstance(long_swf, StringWithFormatting)
+        self.assertEqual(str(long_swf), 'Hello World!Suffix')
+        long_swf = long_swf + Format('SufSuffixFormat')
+        self.assertEqual(long_swf._content, (
+            'Hello ', Format('hiding'), 'World!', 'Suffix',
+            Format('SufSuffixFormat')))
+
+    def test_get_item_index(self):
+        self.assertEqual(self.swf[2], 'l')
+        self.assertEqual(self.swf[7], 'o')
+
+    def test_get_item_slice(self):
+        swf = 'Hello ' + Format('hiding1') + Format('hiding2') + 'World!'
+        expected = 'lo ' + Format('hiding1') + Format('hiding2') + 'World!'
+        self.assertEqual(swf[3:], expected)
+        self.assertEqual(swf[3:100], expected)
+        self.assertEqual(swf[3:len(self.swf)], expected)
+        expected = 'o ' + Format('hiding1') + Format('hiding2') + 'Wor'
+        self.assertEqual(swf[4:9], expected)
+        expected = StringWithFormatting(['llo'])
+        self.assertEqual(swf[2:5], expected)
+        expected = StringWithFormatting(['llo '])
+        self.assertEqual(swf[2:6], expected)
+        expected = 'Hello ' + Format('hiding1') + Format('hiding2') + 'Wo'
+        self.assertEqual(swf[:8], expected)
+        expected = 'ello ' + Format('hiding1') + Format('hiding2') + 'Worl'
+        self.assertEqual(swf[1:10], expected)
+        expected = Format('hiding1') + Format('hiding2') + 'World'
+        self.assertEqual(swf[6:11], expected)
+        expected = Format('hiding1') + Format('hiding2') + 'orld!'
+        self.assertEqual(swf[7:12], expected)
+        expected = StringWithFormatting((Format('hiding1'), Format('hiding2')))
+        self.assertEqual(swf[100:110], expected)
+        swf = Format('one') + Format('two') + 'message'
+        # FIXME: This is potentially leaky, as we just have to keep
+        # concatenating every Format we have, because we don't know which ones
+        # cancel each other out.
+        expected = Format('one') + Format('two') + 'sage'
+        self.assertEqual(swf[3:], expected)

--- a/test/test_formatted_string.py
+++ b/test/test_formatted_string.py
@@ -3,19 +3,7 @@ from io import StringIO
 import blessings
 
 from junction.formatting import Format, StringWithFormatting, TextWrapper, wrap
-from junction.formatting import Format, StringWithFormatting
-#
-#    def _test_formatting_in_content(self):
-#        text = Text(
-#            self.terminal.bold + 'The ' + self.terminal.normal + 'quick ' +
-#            self.terminal.red('brown') + ' fox ' +
-#            self.terminal.underline('jumps') +
-#            ' over {t.green_on_white}the lazy{t.normal} dog'.format(
-#                t=self.terminal))
-#
-#    def _test_default_formatting_inherited_in_container(self):
-#        pass
-from junction import Terminal, Fill, Text, Stack
+from junction import Terminal, Fill
 
 long_swf = (
     '  This is a    rather ' + Format('bold') + 'loooong ' + Format('normal') +
@@ -37,19 +25,6 @@ class TestFormattingBehviour(TestCase):
         self.assertEqual(
             self.stream.getvalue(),
             bless_term.bold + bless_term.move(0, 0) + '...')
-
-    def _test_formatting_in_content(self):
-        text = Text(
-            self.terminal.bold + 'The ' + self.terminal.normal + 'quick ' +
-            self.terminal.red('brown') + ' fox ' +
-            self.terminal.underline('jumps') +
-            ' over {t.green_on_white}the lazy{t.normal} dog'.format(
-                t=self.terminal))
-        text.terminal = self.terminal
-        text.draw(13, 10)
-
-    def _test_default_formatting_inherited_in_container(self):
-        pass
 
 
 class TestFormat(TestCase):

--- a/test/test_formatted_string.py
+++ b/test/test_formatted_string.py
@@ -150,7 +150,7 @@ class TestStringWithFormatting(TestCase):
         long_swf = Format('PrePrefixFormat') + long_swf
         self.assertIsInstance(long_swf, StringWithFormatting)
         self.assertEqual(long_swf._content, (
-            Format('PrePrefixFormat'), 'Prefix', 'Hello ', Format('hiding'),
+            Format('PrePrefixFormat'), 'PrefixHello ', Format('hiding'),
             'World!'))
         # String suffix
         long_swf = self.swf + 'Suffix'
@@ -159,13 +159,17 @@ class TestStringWithFormatting(TestCase):
         # Format suffix
         long_swf = long_swf + Format('SufSuffixFormat')
         self.assertEqual(long_swf._content, (
-            'Hello ', Format('hiding'), 'World!', 'Suffix',
+            'Hello ', Format('hiding'), 'World!Suffix',
             Format('SufSuffixFormat')))
         # Adding two StringWithFormatting objects
         long_swf = self.swf + self.swf
         self.assertEqual(long_swf._content, (
-            'Hello ', Format('hiding'), 'World!', 'Hello ', Format('hiding'),
+            'Hello ', Format('hiding'), 'World!Hello ', Format('hiding'),
             'World!'))
+        # Reverse-adding a str:
+        long_swf = 'fantastic' + self.swf
+        self.assertEqual(long_swf._content, (
+            'fantasticHello ', Format('hiding'), 'World!'))
 
     def test_get_item_index(self):
         self.assertEqual(self.swf[2], 'l')

--- a/test/test_formatted_string.py
+++ b/test/test_formatted_string.py
@@ -70,21 +70,30 @@ class TestStringWithFormatting(TestCase):
         self.assertNotEqual(self.swf, StringWithFormatting('Hello World!'))
 
     def test_addition(self):
+        # String prefix
         long_swf = 'Prefix' + self.swf
         self.assertIsInstance(long_swf, StringWithFormatting)
         self.assertEqual(str(long_swf), 'PrefixHello World!')
+        # Format prefix
         long_swf = Format('PrePrefixFormat') + long_swf
         self.assertIsInstance(long_swf, StringWithFormatting)
         self.assertEqual(long_swf._content, (
             Format('PrePrefixFormat'), 'Prefix', 'Hello ', Format('hiding'),
             'World!'))
+        # String suffix
         long_swf = self.swf + 'Suffix'
         self.assertIsInstance(long_swf, StringWithFormatting)
         self.assertEqual(str(long_swf), 'Hello World!Suffix')
+        # Format suffix
         long_swf = long_swf + Format('SufSuffixFormat')
         self.assertEqual(long_swf._content, (
             'Hello ', Format('hiding'), 'World!', 'Suffix',
             Format('SufSuffixFormat')))
+        # Adding two StringWithFormatting objects
+        long_swf = self.swf + self.swf
+        self.assertEqual(long_swf._content, (
+            'Hello ', Format('hiding'), 'World!', 'Hello ', Format('hiding'),
+            'World!'))
 
     def test_get_item_index(self):
         self.assertEqual(self.swf[2], 'l')

--- a/test/test_formatted_string.py
+++ b/test/test_formatted_string.py
@@ -287,6 +287,7 @@ class TestTextWrapper(TestCase):
             'over the lazy',
             'dog']
         self.assertEqual(result, expected)
+        self.assertEqual(wrap('', 10), [''])
 
     def test_wrap_str_with_formatting(self):
         result = wrap(long_swf, width=11)
@@ -297,4 +298,8 @@ class TestTextWrapper(TestCase):
             'string that',
             'needs wrapp',
             'pppping']
+        self.assertEqual(result, expected)
+        swf = Format('normal') + 'hello'
+        result = wrap(swf, 3)
+        expected = [StringWithFormatting((Format('normal'), 'hel')), 'lo']
         self.assertEqual(result, expected)

--- a/test/test_terminal.py
+++ b/test/test_terminal.py
@@ -10,8 +10,7 @@ class TestTerminal(TestCase):
     def test_draw_block(self):
         self.maxDiff = 0  # protect from difficult terminal output on failure
         blessings_term = blessings.Terminal(force_styling=True)
-        test_term = Terminal()
-        test_term.stream = StringIO()
+        test_term = Terminal(stream=StringIO(), force_styling=True)
         test_term.draw_block(['hello', 'world'], x=3, y=4)
         self.assertEqual(
             test_term.stream.getvalue(),


### PR DESCRIPTION
This branch adds some functionality for handling formatting from our blessings-like `Terminal` object in a way which is hopefully nice for the user and useful internally. We introduce a new `StringWithFormatting` object, which tries to emulate a normal string, but with hidden formatting metadata that does not count towards things like string length.

Sadly, the extra object means we need to re-implement some low-level functionality, like word wrapping, to take the new Format objects into account. The algorithmic stuff is probably fairly hideous, but it's unit tested and does the job for now.

I also added an example of how nice makes creating a Text object with formatting statements in it.
